### PR TITLE
Update gof-strategy.md

### DIFF
--- a/gof-strategy.md
+++ b/gof-strategy.md
@@ -530,8 +530,8 @@ uniqueIO :: Eq a
          -> IO Bool
          
 uniqueIO input sort =
-  if V.null sorted then return True
-                   else check
+  if V.null input then return True
+                  else check
   where
     check = do
       sorted <- sort input
@@ -569,8 +569,8 @@ uniqueM :: (Eq a, Monad m)
         -> m Bool
             
 uniqueM input sort =
-  if V.null sorted then return True
-                   else check
+  if V.null input then return True
+                  else check
   where
     check = do
       sorted <- sort input


### PR DESCRIPTION
`sorted` isn't in scope when used in `uniqueIO` and `uniqueM`. I would suggest changing the bodies of all the `unique` functions to use `V.null input` but I'm not sure if that's a larger change than you want.